### PR TITLE
 Integrate SkinModel with glove database operations for paintkit support

### DIFF
--- a/src/WeaponSkins.Database/CRUD/DatabaseService.Gloves.cs
+++ b/src/WeaponSkins.Database/CRUD/DatabaseService.Gloves.cs
@@ -12,6 +12,10 @@ public partial class DatabaseService
         await fsql.InsertOrUpdate<GloveModel>()
             .SetSource(gloves.Select(glove => GloveModel.FromDataModel(glove)))
             .ExecuteAffrowsAsync();
+
+        await fsql.InsertOrUpdate<SkinModel>()
+            .SetSource(gloves.Select(glove => SkinModel.FromGloveDataModel(glove)))
+            .ExecuteAffrowsAsync();
     }
 
     public async Task<GloveData?> GetGloveAsync(ulong steamId,
@@ -20,21 +24,74 @@ public partial class DatabaseService
         var model = await fsql.Select<GloveModel>()
             .Where(glove => glove.SteamID == steamId.ToString() && glove.Team == (short)team)
             .ToOneAsync();
-        return model.ToDataModel();
+
+        var data = model.ToDataModel();
+        var skinModel = await fsql.Select<SkinModel>()
+            .Where(skin => skin.SteamID == steamId.ToString() && skin.Team == (short)team &&
+                           skin.DefinitionIndex == data.DefinitionIndex)
+            .ToOneAsync();
+
+        if (skinModel != null)
+        {
+            data.Paintkit = skinModel.PaintID;
+            data.PaintkitWear = skinModel.Wear;
+            data.PaintkitSeed = skinModel.Seed;
+        }
+
+        return data;
     }
 
     public async Task<IEnumerable<GloveData>> GetGlovesAsync(ulong steamId)
     {
-        return await fsql.Select<GloveModel>()
-            .Where(glove => glove.SteamID == steamId.ToString())
-            .ToListAsync()
-            .ContinueWith(task => task.Result.Select(glove => glove.ToDataModel()));
+        var results = await fsql.Select<GloveModel, SkinModel>()
+            .LeftJoin((glove,
+                    skin) =>
+                glove.SteamID == skin.SteamID &&
+                glove.Team == skin.Team &&
+                glove.DefinitionIndex == skin.DefinitionIndex)
+            .Where((glove, skin) => glove.SteamID == steamId.ToString())
+            .ToListAsync((Glove,
+                Skin) => new { Glove, Skin });
+
+        return results.Select(item =>
+        {
+            var data = item.Glove.ToDataModel();
+
+            if (item.Skin != null)
+            {
+                data.Paintkit = item.Skin.PaintID;
+                data.PaintkitWear = item.Skin.Wear;
+                data.PaintkitSeed = item.Skin.Seed;
+            }
+
+            return data;
+        }).ToList();
     }
 
     public async Task<IEnumerable<GloveData>> GetAllGlovesAsync()
     {
-        return await fsql.Select<GloveModel>().ToListAsync()
-            .ContinueWith(task => task.Result.Select(glove => glove.ToDataModel()));
+        var results = await fsql.Select<GloveModel, SkinModel>()
+            .LeftJoin((glove,
+                    skin) =>
+                glove.SteamID == skin.SteamID &&
+                glove.Team == skin.Team &&
+                glove.DefinitionIndex == skin.DefinitionIndex)
+            .ToListAsync((Glove,
+                Skin) => new { Glove, Skin });
+
+        return results.Select(item =>
+        {
+            var data = item.Glove.ToDataModel();
+
+            if (item.Skin != null)
+            {
+                data.Paintkit = item.Skin.PaintID;
+                data.PaintkitWear = item.Skin.Wear;
+                data.PaintkitSeed = item.Skin.Seed;
+            }
+
+            return data;
+        }).ToList();
     }
 
     public async Task RemoveGloveAsync(ulong steamId,
@@ -51,4 +108,4 @@ public partial class DatabaseService
             .Where(glove => glove.SteamID == steamId.ToString())
             .ExecuteAffrowsAsync();
     }
-}       
+}

--- a/src/WeaponSkins.Database/Models/SkinModel.cs
+++ b/src/WeaponSkins.Database/Models/SkinModel.cs
@@ -146,4 +146,17 @@ public record SkinModel
             StattrakCount = data.StattrakCount
         };
     }
+
+    public static SkinModel FromGloveDataModel(GloveData data)
+    {
+        return new SkinModel
+        {
+            SteamID = data.SteamID.ToString(),
+            Team = (short)data.Team,
+            DefinitionIndex = data.DefinitionIndex,
+            PaintID = data.Paintkit,
+            Wear = data.PaintkitWear,
+            Seed = data.PaintkitSeed
+        };
+    }
 }


### PR DESCRIPTION
- Add SkinModel insertion/update when saving gloves
- Implement left join between GloveModel and SkinModel in retrieval queries
- Populate paintkit properties (PaintID, Wear, Seed) from SkinModel when available
- Add FromGloveDataModel factory method to SkinModel for glove data conversion
- Apply changes to GetGloveAsync, GetGlovesAsync, and GetAllGlovesAsync methods